### PR TITLE
Add example reverse proxy setup to support Caddy

### DIFF
--- a/server/etc/reverse-proxy/caddy-examples/Caddyfile
+++ b/server/etc/reverse-proxy/caddy-examples/Caddyfile
@@ -1,0 +1,26 @@
+{
+	email [VALID EMAIL ADDRESS] # Used for SSL Certificate generation.
+}
+WEBTILES.DOMAIN.com { # Subdomain for webtiles access.
+	handle {
+		header Connection *Upgrade* # Support websockets
+		header Upgrade websocket
+		reverse_proxy dcss-server:8080 # MUST set up Caddy in DOCKER Container for addressing by container name.
+		# Other potential options to explore: stream_timeout, stream_close_delay, flush_interval
+	}
+}
+MORGUES.DOMAIN.com { # Subdomain for morgues access.
+	reverse_proxy dcss-server:8082
+}
+# Caddy is a lightweight reverse proxy with out-of-the-box automated SSL certificate management.
+# Instructions:
+# 1. Tested with Caddy alpine docker image: https://hub.docker.com/_/caddy
+# 2. Follow Caddy Docker guidance: https://www.docker.com/blog/deploying-web-applications-quicker-and-easier-with-caddy-2/
+# 3. Requires changes to docker-compose.yml:
+#   A. Add a docker network. Recommend "web" and "internal" for Caddy and "internal" for webtiles/nginx. This allows Caddy to address the dcss-server container by name in its configuration files.
+#   B. Internal network = "driver: bridge". Web network = "external: true".
+#   C. Give Caddy external access to ports 80 and 443.
+#   D. Create a folder with a Caddyfile and add it as a volume mount to the caddy image as /etc/Caddy/Caddyfile (see docker guide).
+#   E. Use docker network command to create networks with names "web" and "internal".
+# 4. Launch. Check Caddy container logs to confirm SSL certificate request successful and test connection.
+# NOTE: You will only be able to access internal services through the host name. You/users can only access web services via Caddy.

--- a/server/etc/reverse-proxy/caddy-examples/docker-compose.caddy.yml
+++ b/server/etc/reverse-proxy/caddy-examples/docker-compose.caddy.yml
@@ -1,0 +1,40 @@
+name: server
+services:
+  caddy:
+    image: caddy:alpine
+    networks:
+      internal: null
+      web: null
+    ports:
+      - mode: ingress
+        target: 80
+        published: "80"
+        protocol: tcp
+      - mode: ingress
+        target: 443
+        published: "443"
+        protocol: tcp
+    restart: unless-stopped
+    volumes:
+      - type: bind
+        source: /data/caddy/Caddyfile
+        target: /etc/caddy/Caddyfile
+        bind:
+          create_host_path: true
+      - type: bind
+        source: /data/caddy/data
+        target: /data
+        bind:
+          create_host_path: true
+      - type: bind
+        source: /data/caddy/config
+        target: /config
+        bind:
+          create_host_path: true
+networks:
+  internal:
+    name: server_internal
+    driver: bridge
+  web:
+    name: web
+    external: true

--- a/server/etc/reverse-proxy/caddy-examples/docker-compose.caddy.yml
+++ b/server/etc/reverse-proxy/caddy-examples/docker-compose.caddy.yml
@@ -1,5 +1,8 @@
 name: server
 services:
+  dcss-server:
+    networks:
+      internal: null
   caddy:
     image: caddy:alpine
     networks:


### PR DESCRIPTION
Accidentally closed the other request by messing up my git branch. Sorry for repost.

After almost tearing my hair out trying to figure out how to get nginx to work as a reverse proxy, renew SSL certificates with certbot, and automate that all, I decided to switch to Caddy for our reverse proxy at the server level. Caddy is a lightweight reverse proxy.

Using the official Caddy Docker container image as a base (and for Docker container networking-by-container-name support), all of the SSL management and traffic routing can be accomplished in 14 lines of networking code and 40 additional lines of Docker yaml.

I am submitting this pull request to the "reverse proxy" examples section to document our process in case it's helpful to someone else.
