### PR TITLE
Add container tips and FORCE_CLONE logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ commands inside the container:
 ```bash
 cd /home/crawl-dev/dgamelaunch-config && git pull
 FORCE_CLONE=true $DGL_CONF_HOME/crawl-build/update-public-repository.sh
-update-gcc   # manually install updated dependencies
+dgl update-gcc <FORK_NAME> <BRANCH_NAME>
 $SCRIPTS/web/init.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,10 +109,6 @@ USE_DWEM=true USE_REVERSE_PROXY=true docker compose up -d && docker compose logs
 ### Repository Management
 * This repository is used for the operation of [crawl.nemelex.cards](https://crawl.nemelex.cards).
 * If you need to add new forks or versions, you can request it via a Pull-Request.
-* When adding a new fork to an existing installation, run the update scripts with
-  `FORCE_CLONE=true` to force cloning the crawl repository so that new remotes are
-  configured correctly. After the update, execute `$SCRIPTS/web/init.sh` to refresh
-  web symbolic links.
 
 ### Container Management Tips
 If a new fork is added after the container has already been built, run the following

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ USE_DWEM=true USE_REVERSE_PROXY=true docker compose up -d && docker compose logs
   configured correctly. After the update, execute `$SCRIPTS/web/init.sh` to refresh
   web symbolic links.
 
+### Container Management Tips
+If a new fork is added after the container has already been built, run the following
+commands inside the container:
+
+```bash
+cd /home/crawl-dev/dgamelaunch-config && git pull
+FORCE_CLONE=true $DGL_CONF_HOME/crawl-build/update-public-repository.sh
+update-gcc   # manually install updated dependencies
+$SCRIPTS/web/init.sh
+```
+
 ### Upstream Projects
 * https://github.com/crawl/dgamelaunch-config
 * Scripts necessary for running the Dungeon Crawl Stone Soup server. In `utils/testing-container`, there is a container environment configuration for CI/CD verification tasks of Crawl.

--- a/crawl-build/update-public-repository.sh
+++ b/crawl-build/update-public-repository.sh
@@ -88,6 +88,10 @@ apply-patch() {
 BRANCH=$1
 REVISION="$2"
 clone-crawl-ref
+if [[ -n "$FORCE_CLONE" ]]; then
+    say "FORCE_CLONE requested; repository cloned. Exiting."
+    exit 0
+fi
 [[ -n "$BRANCH" ]] || abort-saying "$0: Checkout branch not specified!"
 update-crawl-ref
 update-submodules


### PR DESCRIPTION
## Summary
- document container management commands
- exit early when `FORCE_CLONE` is used in `update-public-repository.sh`

## Testing
- `bin/dgl test` *(fails: Cannot find dgamelaunch binary)*

------
https://chatgpt.com/codex/tasks/task_e_683c01d1c928833390a0cf6034b7854a