### PR TITLE
Fix versions.conf comma issue

### DIFF
--- a/server/scripts/game/install-trunk.sh
+++ b/server/scripts/game/install-trunk.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source "$DGL_CONF_HOME/dgl-manage.conf"
-dgl update-trunk | tee -a /home/crawl-dev/logs/stable.log
+dgl update-trunk | tee -a /home/crawl-dev/logs/trunk.log

--- a/versions.conf
+++ b/versions.conf
@@ -1,4 +1,4 @@
 #! /bin/bash
 
 VERSIONS="git $(seq 11 33 | sed 's/^/0./')"
-VERSIONS+=" dcssca hellcrawl gnollcrawl bcrawl bloatcrawl2 gooncrawl xcrawl stoatsoup bcadrencrawl kimchicrawl addedcrawl dcst, nostalgia, yiufcrawl, oofcrawl, boggartcrawl"
+VERSIONS+=" dcssca hellcrawl gnollcrawl bcrawl bloatcrawl2 gooncrawl xcrawl stoatsoup bcadrencrawl kimchicrawl addedcrawl dcst nostalgia yiufcrawl oofcrawl boggartcrawl"


### PR DESCRIPTION
I saw that new folder paths have a comma in them when looking at the meta folder in https://archive.nemelex.cards/meta/

Cause by copy pasting by me, this is a fix. Also fixes log path in install-trunk command