### PR TITLE
Reduce Docker build package footprint

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -25,8 +25,10 @@ RUN apt-get install -y nginx nginx-extras fcgiwrap spawn-fcgi && mkdir -p /var/r
 RUN echo "deb [trusted=yes] http://archive.ubuntu.com/ubuntu/ bionic main universe" >> /etc/apt/sources.list && \
     echo "deb [trusted=yes] http://archive.ubuntu.com/ubuntu/ focal main universe" >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get install -y gcc-6 g++-6 gcc-7 g++-7 gdb && \
-    apt-get install -y libsdl1.2-dev libsdl-image1.2-dev
+    apt-get install -y --no-install-recommends \
+        gcc-6 g++-6 gcc-7 g++-7 gdb \
+        libsdl1.2-dev libsdl-image1.2-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install tornado jinja2 --break-system-packages \
 && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Summary
- install old gcc/SDL build dependencies with --no-install-recommends
- clean apt lists in the same Docker layer
- avoids pulling large Mesa/Vulkan recommended packages that caused GitHub Actions to run out of disk during Docker build

## Testing
- inspected latest failed Actions log: Docker build failed while unpacking mesa-vulkan-drivers with No space left on device
- local Docker build not run because this host has limited free root disk and the scheduled Actions failure is on GitHub-hosted runners
