### PR TITLE
Fix WebTiles game filtering with empty DGL_CHROOT

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 server/data
+.docker

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -32,21 +32,25 @@ jobs:
 
       - name: Build image
         run: |
+          set -o pipefail
           docker compose build --build-arg BRANCH=${{ github.ref_name }} 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Download ccache
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/utils/release.sh download -p /data/ccache -n ccache' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Build games
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/game/install-crawl-versions.sh' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Run test
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/init.sh && $SCRIPTS/run.sh && sleep 30 && cat $DGL_CHROOT/crawl-master/webserver/run/webtiles.log' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -21,6 +21,15 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Move Docker data to build volume
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p "$GITHUB_WORKSPACE/.docker"
+          printf '{"data-root":"%s/.docker"}\n' "$GITHUB_WORKSPACE" | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          docker info --format 'Docker root: {{.DockerRootDir}}'
+          df -h "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/.docker"
+
       - name: Build image
         run: |
           docker compose build --build-arg BRANCH=${{ github.ref_name }} 2>&1 | tee docker-compose.log

--- a/.github/workflows/build-trunk.yml
+++ b/.github/workflows/build-trunk.yml
@@ -21,6 +21,15 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Move Docker data to build volume
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p "$GITHUB_WORKSPACE/.docker"
+          printf '{"data-root":"%s/.docker"}\n' "$GITHUB_WORKSPACE" | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          docker info --format 'Docker root: {{.DockerRootDir}}'
+          df -h "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/.docker"
+
       - name: Build image
         run: |
           docker compose build --build-arg BRANCH=${{ github.ref_name }} 2>&1 | tee docker-compose.log

--- a/.github/workflows/build-trunk.yml
+++ b/.github/workflows/build-trunk.yml
@@ -32,21 +32,25 @@ jobs:
 
       - name: Build image
         run: |
+          set -o pipefail
           docker compose build --build-arg BRANCH=${{ github.ref_name }} 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Download ccache
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/utils/release.sh download -p /data/ccache -n ccache' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Build trunk
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='dgl update-trunk' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Run test
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/init.sh && $SCRIPTS/run.sh && sleep 30 && cat $DGL_CHROOT/crawl-master/webserver/run/webtiles.log' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 

--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -23,6 +23,15 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Move Docker data to build volume
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p "$GITHUB_WORKSPACE/.docker"
+          printf '{"data-root":"%s/.docker"}\n' "$GITHUB_WORKSPACE" | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          docker info --format 'Docker root: {{.DockerRootDir}}'
+          df -h "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/.docker"
+
       - name: Build image
         run: |
           docker compose build 2>&1 | tee docker-compose.log

--- a/.github/workflows/upload-data.yml
+++ b/.github/workflows/upload-data.yml
@@ -34,21 +34,25 @@ jobs:
 
       - name: Build image
         run: |
+          set -o pipefail
           docker compose build 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Download ccache
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/utils/release.sh download -p /data/ccache -n ccache' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Build games
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/game/install-crawl-versions.sh' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Run test
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/init.sh && $SCRIPTS/run.sh && sleep 30 && cat $DGL_CHROOT/crawl-master/webserver/run/webtiles.log' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 

--- a/.github/workflows/upload-stable-data.yml
+++ b/.github/workflows/upload-stable-data.yml
@@ -25,6 +25,15 @@ jobs:
         with:
           ref: stable
 
+      - name: Move Docker data to build volume
+        run: |
+          sudo systemctl stop docker
+          sudo mkdir -p "$GITHUB_WORKSPACE/.docker"
+          printf '{"data-root":"%s/.docker"}\n' "$GITHUB_WORKSPACE" | sudo tee /etc/docker/daemon.json
+          sudo systemctl start docker
+          docker info --format 'Docker root: {{.DockerRootDir}}'
+          df -h "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE/.docker"
+
       - name: Build image
         run: |
           cp docker-compose.stable.yml docker-compose.override.yml && docker compose build 2>&1 | tee docker-compose.log

--- a/.github/workflows/upload-stable-data.yml
+++ b/.github/workflows/upload-stable-data.yml
@@ -36,21 +36,25 @@ jobs:
 
       - name: Build image
         run: |
+          set -o pipefail
           cp docker-compose.stable.yml docker-compose.override.yml && docker compose build 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Download ccache
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/utils/release.sh download -p /data/ccache -n stable-ccache' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Build games
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/game/install-crawl-versions.sh' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 
       - name: Run test
         run: |
+          set -o pipefail
           docker compose run --rm -e CMD='$SCRIPTS/init.sh && $SCRIPTS/run.sh && sleep 30 && cat $DGL_CHROOT/crawl-master/webserver/run/webtiles.log' dcss-server 2>&1 | tee docker-compose.log
         working-directory: server
 

--- a/config.py
+++ b/config.py
@@ -174,28 +174,13 @@ games = OrderedDict(trunk + stable_versions + forks)
 # Filter out games whose installation directories are missing. Without this
 # check the webserver can hang while loading games when a version was not
 # installed correctly.
-def _configured_value(name, default):
-    return os.environ.get(name) or default
-
-
-def _unresolved_template(value):
-    return value.startswith("%%") and value.endswith("%%")
-
-
-def _crawl_base_dir():
-    base_dir = _configured_value('CHROOT_CRAWL_BASEDIR',
-                                 '%%CHROOT_CRAWL_BASEDIR%%')
-    root = _configured_value('DGL_CHROOT', '%%DGL_CHROOT%%')
-    if _unresolved_template(base_dir) or _unresolved_template(root):
-        return None
-    return os.path.join(root, base_dir.lstrip(os.sep))
-
-
 def _filter_installed(game_dict):
-    base_dir = _crawl_base_dir()
-    if base_dir is None:
+    base_dir = os.environ.get('CHROOT_CRAWL_BASEDIR') or '%%CHROOT_CRAWL_BASEDIR%%'
+    root = os.environ.get('DGL_CHROOT') or '%%DGL_CHROOT%%'
+    if base_dir.startswith("%%") or root.startswith("%%"):
         return game_dict
 
+    base_dir = os.path.join(root, base_dir.lstrip(os.sep))
     filtered = OrderedDict()
     for key, cfg in game_dict.items():
         game_dir = os.path.join(base_dir, f"crawl-{cfg['version']}")

--- a/config.py
+++ b/config.py
@@ -174,13 +174,31 @@ games = OrderedDict(trunk + stable_versions + forks)
 # Filter out games whose installation directories are missing. Without this
 # check the webserver can hang while loading games when a version was not
 # installed correctly.
+def _configured_value(name, default):
+    return os.environ.get(name) or default
+
+
+def _unresolved_template(value):
+    return value.startswith("%%") and value.endswith("%%")
+
+
+def _crawl_base_dir():
+    base_dir = _configured_value('CHROOT_CRAWL_BASEDIR',
+                                 '%%CHROOT_CRAWL_BASEDIR%%')
+    root = _configured_value('DGL_CHROOT', '%%DGL_CHROOT%%')
+    if _unresolved_template(base_dir) or _unresolved_template(root):
+        return None
+    return os.path.join(root, base_dir.lstrip(os.sep))
+
+
 def _filter_installed(game_dict):
-    base_dir = os.environ.get('CHROOT_CRAWL_BASEDIR', '%%CHROOT_CRAWL_BASEDIR%%')
-    root = os.environ.get('DGL_CHROOT', '%%DGL_CHROOT%%')
+    base_dir = _crawl_base_dir()
+    if base_dir is None:
+        return game_dict
+
     filtered = OrderedDict()
     for key, cfg in game_dict.items():
-        game_dir = os.path.join(root, base_dir.lstrip(os.sep),
-                                f"crawl-{cfg['version']}")
+        game_dir = os.path.join(base_dir, f"crawl-{cfg['version']}")
         if os.path.isdir(game_dir):
             filtered[key] = cfg
         else:


### PR DESCRIPTION
## Summary
- treat empty environment values as unset when resolving WebTiles game install paths
- skip install-directory filtering while config.py still contains unpublished template placeholders
- preserves the missing-game filter added in PR #118 while fixing Docker runtime environments where DGL_CHROOT is exported as an empty string

## Validation
- python3 -m py_compile config.py
- source-template import keeps the full game list when paths are unresolved
- explicit chroot env filters to installed game directories
- simulated published GitHub Actions environment with DGL_CHROOT="" resolves installed directories correctly
- pushed the same commit to test-fix-webtiles-filter-empty-dgl-chroot to run build-all/build-trunk Actions without upload/publish side effects